### PR TITLE
Refactored OrderTriggerHandler to move SOQL out of loop and added hig…

### DIFF
--- a/force-app/main/default/classes/OrderTriggerHandler.cls
+++ b/force-app/main/default/classes/OrderTriggerHandler.cls
@@ -14,9 +14,9 @@ public class OrderTriggerHandler {
         }
     }
 
-    public static void beforeDelete(List<Order> oldOrders) {
+    public static void beforeInsert(List<Order> newOrders) {
         Set<Id> accountIds = new Set<Id>();
-        for (Order ord : oldOrders) {
+        for (Order ord : newOrders) {
             if (ord.AccountId != null) {
                 accountIds.add(ord.AccountId);
             }
@@ -25,15 +25,43 @@ public class OrderTriggerHandler {
         if (!accountIds.isEmpty()) {
             List<Account> accounts = [SELECT Id, Active__c FROM Account WHERE Id IN :accountIds];
             for (Account acc : accounts) {
-                Boolean hasOtherOrders = [SELECT COUNT() FROM Order WHERE AccountId = :acc.Id AND Id NOT IN :oldOrders] > 0;
-                if (!hasOtherOrders) {
-                    acc.Active__c = false;
-                }
+                acc.Active__c = true;
             }
             update accounts;
         }
     }
+
+    public static void afterDelete(List<Order> oldOrders) {
+        Set<Id> accountIds = new Set<Id>();
+        for (Order ord : oldOrders) {
+            if (ord.AccountId != null) {
+                accountIds.add(ord.AccountId);
+            }
+        }
+
+        if (!accountIds.isEmpty()) {
+            // Extraire les IDs des comptes avec d'autres commandes
+            Map<Id, Integer> orderCountMap = new Map<Id, Integer>();
+            for (AggregateResult ar : [
+                SELECT AccountId, COUNT(Id) orderCount
+                FROM Order
+                WHERE AccountId IN :accountIds
+                GROUP BY AccountId
+            ]) {
+                orderCountMap.put((Id) ar.get('AccountId'), (Integer) ar.get('orderCount'));
+            }
+
+            List<Account> accountsToUpdate = new List<Account>();
+            for (Account acc : [SELECT Id, Active__c FROM Account WHERE Id IN :accountIds]) {
+                if (!orderCountMap.containsKey(acc.Id) || orderCountMap.get(acc.Id) == 0) {
+                    acc.Active__c = false;
+                    accountsToUpdate.add(acc);
+                }
+            }
+            
+            if (!accountsToUpdate.isEmpty()) {
+                update accountsToUpdate;
+            }
+        }
+    }
 }
-    
-
-

--- a/force-app/main/default/classes/OrderTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/OrderTriggerHandlerTest.cls
@@ -4,7 +4,7 @@ public class OrderTriggerHandlerTest {
     @testSetup
     static void setupTestData() {
         // Créer les données de test nécessaires pour tous les tests
-        Account testAccount = new Account(Name = 'Test Account');
+        Account testAccount = new Account(Name = 'Test Account', Active__c = false);
         insert testAccount;
 
         Contract testContract = new Contract(
@@ -164,9 +164,31 @@ public class OrderTriggerHandlerTest {
     }
 
     @isTest
-    static void testAccountRemainsActiveAfterSingleOrderDeletion() {
-        // Configuration des données de test
+    static void testAccountIsActiveAfterOrderInsertion() {
+        // Récupérer le compte "Test Account"
         Account acc = [SELECT Id, Active__c FROM Account WHERE Name = 'Test Account' LIMIT 1];
+        // Vérifier que le champ Active__c est actif ou non
+        System.assertEquals(false, acc.Active__c, 'Account should be inactive initially');
+    
+        // Insérer un nouvel ordre
+        Order newOrder = new Order(
+            AccountId = acc.Id,
+            Status = 'Draft',
+            EffectiveDate = Date.today(),
+            Pricebook2Id = Test.getStandardPricebookId()
+        );
+        insert newOrder;
+    
+        // Vérifier que le compte devient actif après l'insertion de l'ordre
+        Account updatedAccount = [SELECT Active__c FROM Account WHERE Id = :acc.Id];
+        System.assertEquals(true, updatedAccount.Active__c, 'Account should become active after order insertion');
+    }
+
+    @isTest
+    static void testAccountRemainsActiveAfterSingleOrderDeletion() {
+        Account acc = [SELECT Id, Active__c FROM Account WHERE Name = 'Test Account' LIMIT 1];
+        System.assertEquals(false, acc.Active__c, 'Account should be inactive initially');
+
         Contract con = [SELECT Id, Status FROM Contract WHERE AccountId = :acc.Id LIMIT 1];
         con.Status = 'Activated';
         update con;
@@ -227,8 +249,9 @@ public class OrderTriggerHandlerTest {
 
     @isTest
     static void testAccountBecomesInactiveAfterAllOrdersDeletion() {
-        // Configuration des données de test
         Account acc = [SELECT Id, Active__c FROM Account WHERE Name = 'Test Account' LIMIT 1];
+        System.assertEquals(false, acc.Active__c, 'Account should be inactive initially');
+
         Contract con = [SELECT Id, Status FROM Contract WHERE AccountId = :acc.Id LIMIT 1];
         con.Status = 'Activated';
         update con;
@@ -284,5 +307,49 @@ public class OrderTriggerHandlerTest {
 
         Account updatedAcc2 = [SELECT Active__c FROM Account WHERE Id = :acc.Id];
         System.assertEquals(false, updatedAcc2.Active__c, 'Account should be inactive after deleting all orders');
+    }
+
+    @isTest
+    static void testHighVolumeOrders() {
+        // Test pour vérifier la mise à jour du champ Active__c avec un grand volume de commandes
+        Account acc = [SELECT Id FROM Account WHERE Name = 'Test Account' LIMIT 1];
+        Id priceBookEntryId = TestDataFactory.createTestProductAndPriceBookEntry();
+
+        List<Order> orders = new List<Order>();
+        List<OrderItem> orderItems = new List<OrderItem>();
+
+        for (Integer i = 0; i < 250; i++) {
+            Order ord = new Order(
+                AccountId = acc.Id,
+                Status = 'Draft',
+                EffectiveDate = Date.today(),
+                Pricebook2Id = Test.getStandardPricebookId()
+            );
+            orders.add(ord);
+        }
+        insert orders;
+
+        for (Order ord : orders) {
+            OrderItem ordItem = new OrderItem(
+                OrderId = ord.Id,
+                Quantity = 1,
+                PricebookEntryId = priceBookEntryId,
+                UnitPrice = 5000.00
+            );
+            orderItems.add(ordItem);
+        }
+        insert orderItems;
+
+        // Vérifier que le compte est actif après l'insertion des commandes
+        Account updatedAcc = [SELECT Active__c FROM Account WHERE Id = :acc.Id];
+        System.assertEquals(true, updatedAcc.Active__c, 'Account should be active after inserting high volume of orders');
+
+        Test.startTest();
+        delete orders;
+        Test.stopTest();
+
+        // Vérifier que le compte devient inactif après la suppression de toutes les commandes
+        updatedAcc = [SELECT Active__c FROM Account WHERE Id = :acc.Id];
+        System.assertEquals(false, updatedAcc.Active__c, 'Account should be inactive after deleting all high volume orders');
     }
 }

--- a/force-app/main/default/objects/Account/Account.object-meta.xml
+++ b/force-app/main/default/objects/Account/Account.object-meta.xml
@@ -184,22 +184,16 @@
     </actionOverrides>
     <actionOverrides>
         <actionName>View</actionName>
-        <comment>Action override created by Lightning App Builder during activation.</comment>
-        <content>Account_Record_Page</content>
-        <formFactor>Small</formFactor>
-        <skipRecordTypeSelect>false</skipRecordTypeSelect>
-        <type>Flexipage</type>
+        <type>Default</type>
     </actionOverrides>
     <actionOverrides>
         <actionName>View</actionName>
-        <comment>Action override created by Lightning App Builder during activation.</comment>
-        <content>Account_Record_Page</content>
         <formFactor>Large</formFactor>
-        <skipRecordTypeSelect>false</skipRecordTypeSelect>
-        <type>Flexipage</type>
+        <type>Default</type>
     </actionOverrides>
     <actionOverrides>
         <actionName>View</actionName>
+        <formFactor>Small</formFactor>
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>

--- a/force-app/main/default/objects/Account/fields/Active__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Active__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Active__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Active</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/triggers/OrderTrigger.trigger
+++ b/force-app/main/default/triggers/OrderTrigger.trigger
@@ -1,11 +1,12 @@
-trigger OrderTrigger on Order (before update, before delete) {
-    if (Trigger.isUpdate) {
+trigger OrderTrigger on Order (before insert, before update, after delete) {
+    if (Trigger.isInsert && Trigger.isBefore) {
+        OrderTriggerHandler.beforeInsert(Trigger.new);
+    }
+    if (Trigger.isUpdate && Trigger.isBefore) {
         OrderTriggerHandler.beforeUpdate(Trigger.new, Trigger.oldMap);
     }
-    if (Trigger.isDelete) {
-        OrderTriggerHandler.beforeDelete(Trigger.old);
+    if (Trigger.isDelete && Trigger.isAfter
+    ) {
+        OrderTriggerHandler.afterDelete(Trigger.old);
     }
 }
-
-
-


### PR DESCRIPTION
Refactored OrderTriggerHandler:
Moved the SOQL query out of the loop in the afterDelete method for better efficiency and adherence to Salesforce governor limits.
Enhanced OrderTriggerHandlerTest:
Added a high volume orders test to ensure the trigger can handle scenarios with more than 200 orders, verifying the correct update of the Active__c field on the related Account.